### PR TITLE
feat: CORS 테스트용 공개 API 엔드포인트 추가

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/test/TestController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/test/TestController.java
@@ -1,0 +1,16 @@
+package aibe1.proj2.mentoss.feature.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * CORS 테스트용 공개 API
+ */
+@RestController
+public class TestController {
+
+    @GetMapping("/api/test/hello")
+    public String helloTest() {
+        return "CORS 설정이 잘 되었습니다!";
+    }
+}

--- a/src/main/java/aibe1/proj2/mentoss/global/config/SecurityConfig.java
+++ b/src/main/java/aibe1/proj2/mentoss/global/config/SecurityConfig.java
@@ -15,7 +15,15 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+
+/**
+ * Spring Security 설정 클래스
+ */
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -25,12 +33,35 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
 
+    /**
+     * CORS 설정
+     * - 프론트엔드 도메인에서 백엔드 API에 접근 가능하도록 허용
+     * - localhost:5173 (개발), mentoss.vercel.app (배포) 허용
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(Arrays.asList(
+                "http://localhost:5173",
+                "https://mentoss.vercel.app"
+        ));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(Arrays.asList("*"));
+        config.setAllowCredentials(true); // 쿠키 및 인증 정보 포함 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
     // 개발 환경용 설정
     @Bean
     @Profile("dev") // 개발 환경일 때만 이 빈이 활성화됨
     public SecurityFilterChain devSecurityFilterChain(HttpSecurity http) throws Exception {
         // 개발 모드에서는 모든 요청 허용
-        http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 적용
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .csrf(AbstractHttpConfigurer::disable);
         return http.build();
     }
@@ -41,6 +72,8 @@ public class SecurityConfig {
     public SecurityFilterChain prodSecurityFilterChain(HttpSecurity http) throws Exception {
         // JWT 인증 설정 (기존 코드와 동일)
         http
+                // CORS 설정 적용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 // CSRF 비활성화
                 .csrf(AbstractHttpConfigurer::disable)
                 // 세션 관리 방식 설정 (STATELESS = 세션 사용 안 함)
@@ -48,7 +81,7 @@ public class SecurityConfig {
                 // 요청에 대한 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 공개 API 엔드포인트
-                        .requestMatchers("/test/**", "/api/auth/test/public", "/oauth2/**", "/login/**", "/css/**", "/js/**", "/images/**").permitAll()
+                        .requestMatchers("/test/**", "/api/test/**", "/api/auth/test/public", "/oauth2/**", "/login/**", "/css/**", "/js/**", "/images/**").permitAll()
                         // 관리자만 접근 가능한 엔드포인트
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         // 인증된 사용자만 접근 가능한 나머지 엔드포인트
@@ -59,9 +92,9 @@ public class SecurityConfig {
                         .userInfoEndpoint(user -> user.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler)
                 )
-
                 // JWT 인증 필터 추가
                 .addFilterBefore(jwtFilter(), UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 


### PR DESCRIPTION
- /api/test/hello 경로로 접근 가능한 테스트 컨트롤러 생성
- CORS 설정이 정상 작동하는지 프론트엔드에서 검증 가능

목적: 로컬 및 배포 환경에서 CORS 정책 적용 여부 확인