### PR TITLE
feat: Render 슬립 방지를 위한 Ping API 및 GitHub Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -1,0 +1,15 @@
+name: 🕒 Keep Render Server Awake
+
+# 👉 워크플로우 실행 조건
+on:
+  schedule:
+    - cron: "*/5 * * * *"  # ⏰ 매 5분마다 실행 (UTC 기준 → 한국 기준으로는 매 5분)
+  workflow_dispatch:       # 👤 수동 실행도 가능 (GitHub에서 직접 Run Workflow 가능)
+
+jobs:
+  ping-render:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🔔 Render 서버에 ping 요청 보내기
+        run: curl -s https://mentoss.onrender.com/api/ping  # Render 서버의 ping 엔드포인트 호출

--- a/src/main/java/aibe1/proj2/mentoss/feature/ping/PingController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/ping/PingController.java
@@ -1,0 +1,22 @@
+package aibe1.proj2.mentoss.feature.ping;
+
+import aibe1.proj2.mentoss.global.dto.ApiResponseFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Render 서버의 슬립 방지를 위한 Ping API 컨트롤러
+ *
+ * - GitHub Actions에서 주기적으로 이 API를 호출
+ * - 일정 시간마다 호출되면 Render 서버가 슬립되지 않고 유지됨
+ * - 프론트에서는 직접 사용하지 않으며, 내부 유지 목적의 엔드포인트
+ */
+
+@RestController
+public class PingController {
+
+    @GetMapping("/api/ping")
+    public ApiResponseFormat<String> ping() {
+        return ApiResponseFormat.ok("pong");
+    }
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/test/TestController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/test/TestController.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.feature.test;
 
+import aibe1.proj2.mentoss.global.dto.ApiResponseFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
 
     @GetMapping("/api/test/hello")
-    public String helloTest() {
-        return "CORS 설정이 잘 되었습니다!";
+    public ApiResponseFormat<String> helloTest() {
+        return ApiResponseFormat.ok("CORS 설정이 잘 되었습니다!");
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/global/dto/ApiResponseFormat.java
+++ b/src/main/java/aibe1/proj2/mentoss/global/dto/ApiResponseFormat.java
@@ -1,15 +1,38 @@
 package aibe1.proj2.mentoss.global.dto;
 
+/**
+ * 공통 API 응답 포맷 클래스
+ *
+ * @param <T> 응답 데이터 타입
+ *
+ * 이 클래스는 모든 API 응답을 일관된 구조로 제공하기 위해 사용됩니다.
+ * - success: 요청 성공 여부
+ * - message: 응답 메시지 (성공/실패 이유)
+ * - data: 실제 반환 데이터 (제네릭 타입)
+ */
 public record ApiResponseFormat<T>(
-boolean success,
-String message,
-T data
+        boolean success,   // 요청 성공 여부 (true/false)
+        String message,    // 응답 메시지 (ex: 성공했습니다, 실패 사유 등)
+        T data             // 응답 데이터 (없을 경우 null)
 ) {
-public static <T> ApiResponseFormat<T> ok(T data) {
-    return new ApiResponseFormat<>(true, "요청이 성공적으로 처리되었습니다.", data);
-}
 
-public static <T> ApiResponseFormat<T> fail(String message) {
-    return new ApiResponseFormat<>(false, message, null);
-}
+    /**
+     * 성공한 요청에 대한 응답을 생성하는 정적 메서드
+     *
+     * @param data 응답에 담을 실제 데이터
+     * @return 성공 상태의 ApiResponseFormat 객체
+     */
+    public static <T> ApiResponseFormat<T> ok(T data) {
+        return new ApiResponseFormat<>(true, "요청이 성공적으로 처리되었습니다.", data);
+    }
+
+    /**
+     * 실패한 요청에 대한 응답을 생성하는 정적 메서드
+     *
+     * @param message 실패 원인을 설명하는 메시지
+     * @return 실패 상태의 ApiResponseFormat 객체
+     */
+    public static <T> ApiResponseFormat<T> fail(String message) {
+        return new ApiResponseFormat<>(false, message, null);
+    }
 }


### PR DESCRIPTION
## 🔍 주요 변경 사항

### 1. 🔄 Ping API 추가 (`/api/ping`)
- Render 서버가 일정 시간 동안 요청이 없을 경우 슬립되는 문제 방지
- `ApiResponseFormat<String>` 형식으로 `pong` 문자열 반환
- 프론트에서 직접 사용하는 용도는 아님 (외부 모니터링용)

### 2. ⚙️ GitHub Actions 워크플로우 설정
- `.github/workflows/ping-render.yml` 추가
- 매 5분마다 자동으로 `/api/ping` 호출
- Render 서버가 슬립되지 않도록 유지

### 3. 🧹 공통 포맷 스타일 정비
- `ApiResponseFormat<T>` 클래스에 코드 스타일 정돈 및 주석 보완

---

## 🧪 테스트
- 브라우저/터미널에서 `GET /api/ping` 요청 → 정상적으로 `pong` 응답 확인
- GitHub Actions → Actions 탭에서 워크플로우 정상 실행 확인

---

## 📎 관련 커밋
- `chore: GitHub Actions로 Render 서버 유지 워크플로우 설정 (5분 간격 ping)`
- `feat: Render 슬립 방지를 위한 Ping API 추가 (/api/ping)`
- `style(common): ApiResponseFormat 코드 스타일 정돈 및 주석 보완`
