### PR TITLE
과외 문의 기능 추가 및 과외 신청

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
@@ -1,0 +1,55 @@
+package aibe1.proj2.mentoss.feature.application.controller;
+
+import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.service.ApplicationService;
+import aibe1.proj2.mentoss.global.dto.ApiResponseFormat;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/application")
+@RequiredArgsConstructor
+public class ApplicationController {
+
+    private final ApplicationService applicationService;
+    private final Long menteeId = 10L;
+    private final Long mentorId = 1L;
+
+    @Operation(
+            summary = "내가 신청한 과외 목록 조회",
+            description = "현재 로그인한 사용자가 신청한 과외 목록을 조회합니다."
+    )
+    @GetMapping("/my-applied")
+    public ResponseEntity<ApiResponseFormat<List<AppliedLectureResponseDto>>> getMyAppliedLectures() {
+        List<AppliedLectureResponseDto> result = applicationService.getMyAppliedLectures(menteeId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(result));
+    }
+
+    @Operation(
+            summary = "내가 등록한 과외 목록 조회",
+            description = "현재 로그인한 사용자가 등록한 과외 목록을 조회합니다."
+    )
+    @GetMapping("/my-lectures")
+    public ResponseEntity<ApiResponseFormat<List<LectureResponseDto>>> getLecturesByMentor() {
+        List<LectureResponseDto> result = applicationService.getLecturesByMentor(mentorId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(result));
+    }
+
+    @Operation(
+            summary = "신청한 멘티 리스트 조회",
+            description = "특정 강의에 대해 신청한 멘티들의 목록을 조회합니다."
+    )
+    @GetMapping("/{lectureId}/applicants")
+    public ResponseEntity<ApiResponseFormat<List<LectureApplicantDto>>> getLectureApplicants(
+            @PathVariable Long lectureId
+    ) {
+        List<LectureApplicantDto> applicants = applicationService.getApplicantsByLectureId(lectureId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(applicants));
+    }
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
@@ -23,7 +23,7 @@ public class ApplicationController {
             summary = "내가 신청한 과외 목록 조회",
             description = "현재 로그인한 사용자가 신청한 과외 목록을 조회합니다."
     )
-    @GetMapping("/my-applied")
+    @GetMapping("/apply/list")
     public ResponseEntity<ApiResponseFormat<List<AppliedLectureResponseDto>>> getMyAppliedLectures() {
         List<AppliedLectureResponseDto> result = applicationService.getMyAppliedLectures(menteeId);
         return ResponseEntity.ok(ApiResponseFormat.ok(result));
@@ -33,7 +33,7 @@ public class ApplicationController {
             summary = "내가 등록한 과외 목록 조회",
             description = "현재 로그인한 사용자가 등록한 과외 목록을 조회합니다."
     )
-    @GetMapping("/my-lectures")
+    @GetMapping("/apply/lectures/list")
     public ResponseEntity<ApiResponseFormat<List<LectureResponseDto>>> getLecturesByMentor() {
         List<LectureResponseDto> result = applicationService.getLecturesByMentor(mentorId);
         return ResponseEntity.ok(ApiResponseFormat.ok(result));
@@ -70,7 +70,7 @@ public class ApplicationController {
     }
 
     @Operation(summary = "과외 신청 폼 데이터 조회", description = "과외 ID를 통해 신청 폼에 필요한 정보를 조회합니다.")
-    @GetMapping("/{lectureId}/apply-form")
+    @GetMapping("/{lectureId}/form/list")
     public ResponseEntity<ApiResponseFormat<LectureApplyFormDto>> getLectureApplyForm(
             @PathVariable Long lectureId
     ) {

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
@@ -1,8 +1,6 @@
 package aibe1.proj2.mentoss.feature.application.controller;
 
-import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
-import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
-import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.*;
 import aibe1.proj2.mentoss.feature.application.service.ApplicationService;
 import aibe1.proj2.mentoss.global.dto.ApiResponseFormat;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,7 +41,7 @@ public class ApplicationController {
 
     @Operation(
             summary = "신청한 멘티 리스트 조회",
-            description = "특정 강의에 대해 신청한 멘티들의 목록을 조회합니다."
+            description = "특정 과외에 대해 신청한 멘티들의 목록을 조회합니다."
     )
     @GetMapping("/{lectureId}/applicants")
     public ResponseEntity<ApiResponseFormat<List<LectureApplicantDto>>> getLectureApplicants(
@@ -52,4 +50,23 @@ public class ApplicationController {
         List<LectureApplicantDto> applicants = applicationService.getApplicantsByLectureId(lectureId);
         return ResponseEntity.ok(ApiResponseFormat.ok(applicants));
     }
+
+    @Operation(summary = "과외 신청 수락", description = "applicationId를 받아 해당 신청을 수락 처리합니다.")
+    @PostMapping("/approve")
+    public ResponseEntity<ApiResponseFormat<Void>> approveApplication(
+            @RequestBody ApproveApplicationRequestDto dto
+    ) {
+        applicationService.approveApplication(dto.applicationId(), mentorId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(null));
+    }
+
+    @Operation(summary = "과외 신청 반려", description = "applicationId와 반려 사유를 받아 신청을 반려 처리합니다.")
+    @PostMapping("/reject")
+    public ResponseEntity<ApiResponseFormat<Void>> rejectApplication(
+            @RequestBody RejectApplicationRequestDto dto
+            ) {
+        applicationService.rejectApplication(dto.applicationId(), dto.reason(), mentorId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(null));
+    }
+
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
@@ -69,4 +69,22 @@ public class ApplicationController {
         return ResponseEntity.ok(ApiResponseFormat.ok(null));
     }
 
+    @Operation(summary = "과외 신청 폼 데이터 조회", description = "과외 ID를 통해 신청 폼에 필요한 정보를 조회합니다.")
+    @GetMapping("/{lectureId}/apply-form")
+    public ResponseEntity<ApiResponseFormat<LectureApplyFormDto>> getLectureApplyForm(
+            @PathVariable Long lectureId
+    ) {
+        LectureApplyFormDto dto = applicationService.getLectureApplyForm(lectureId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(dto));
+    }
+
+
+    @Operation(summary = "과외 신청", description = "특정 과외에 대해 신청을 보냅니다. 신청 시간과 선택 메시지를 포함합니다.")
+    @PostMapping("/apply")
+    public ResponseEntity<ApiResponseFormat<Void>> applyForLecture(
+            @RequestBody LectureApplyRequestDto dto
+    ) {
+        applicationService.applyForLecture(dto, menteeId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(null));
+    }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/ApplicationInfoDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/ApplicationInfoDto.java
@@ -1,0 +1,7 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record ApplicationInfoDto(
+        Long menteeId,
+        String lectureTitle
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/AppliedLectureResponseDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/AppliedLectureResponseDto.java
@@ -1,0 +1,15 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record AppliedLectureResponseDto(
+        Long applicationId,
+        String status,
+        String lectureTitle,
+        Long price,
+        String nickname,
+        Boolean isCertified,
+        double averageRating,
+        String preferredRegions,
+        String subcategory,
+        String profile_image
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/ApproveApplicationRequestDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/ApproveApplicationRequestDto.java
@@ -1,0 +1,6 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record ApproveApplicationRequestDto(
+        Long applicationId
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplicantDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplicantDto.java
@@ -1,0 +1,10 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record LectureApplicantDto(
+        Long applicationId,
+        String nickname,
+        String lectureTitle,
+        String createdAt,
+        String profileImage
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplyFormDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplyFormDto.java
@@ -1,0 +1,16 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+import java.util.List;
+
+public record LectureApplyFormDto(
+        Long lectureId,
+        String lectureTitle,
+        List<TimeSlot> availableTimeSlots,
+        String profileImage,
+        String nickname,
+        String education,
+        String major,
+        boolean isCertified,
+        double averageRating
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplyFormRawDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplyFormRawDto.java
@@ -1,0 +1,14 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record LectureApplyFormRawDto(
+        Long lectureId,
+        String lectureTitle,
+        String availableTimeSlots, // JSON 문자열
+        String profileImage,
+        String nickname,
+        String education,
+        String major,
+        boolean isCertified,
+        double averageRating
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplyRequestDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureApplyRequestDto.java
@@ -1,0 +1,10 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+import java.util.List;
+
+public record LectureApplyRequestDto(
+        Long lectureId,
+        List<TimeSlot> requestedTimeSlots,
+        String message
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureResponseDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureResponseDto.java
@@ -1,0 +1,12 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record LectureResponseDto(
+        Long lectureId,
+        String lectureTitle,
+        Long price,
+        double averageRating,
+        String preferredRegions,
+        String subcategory,
+        String profile_image
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureSimpleInfoDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/LectureSimpleInfoDto.java
@@ -1,0 +1,7 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record LectureSimpleInfoDto(
+        String lectureTitle,
+        Long mentorId
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/RejectApplicationRequestDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/RejectApplicationRequestDto.java
@@ -1,0 +1,7 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record RejectApplicationRequestDto(
+        Long applicationId,
+        String reason
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/TimeSlot.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/dto/TimeSlot.java
@@ -1,0 +1,7 @@
+package aibe1.proj2.mentoss.feature.application.model.dto;
+
+public record TimeSlot(
+        String dayOfWeek,
+        String startTime,
+        String endTime
+) {}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
@@ -1,0 +1,133 @@
+package aibe1.proj2.mentoss.feature.application.model.mapper;
+
+import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
+import aibe1.proj2.mentoss.global.entity.Application;
+import aibe1.proj2.mentoss.global.entity.Lecture;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@Mapper
+public interface ApplicationMapper {
+
+    // 내가 신청한 과외 목록
+    @Select("""
+                SELECT
+                    a.application_id,
+                    a.status,
+                    l.lecture_title,
+                    l.price,
+                    u.nickname,
+                    mp.is_certified,
+                    COALESCE(rv_avg.average_rating, 0) AS average_rating,
+                    rg.preferred_regions,
+                    lc.subcategory,
+                    u.profile_image
+                FROM application a
+                LEFT JOIN lecture l ON a.lecture_id = l.lecture_id
+                LEFT JOIN mentor_profile mp ON l.mentor_id = mp.mentor_id
+                LEFT JOIN app_user u ON mp.user_id = u.user_id
+                LEFT JOIN lecture_category lc ON l.category_id = lc.category_id
+                LEFT JOIN (
+                    SELECT lecture_id, ROUND(AVG(rating), 1) AS average_rating
+                    FROM review
+                    WHERE is_deleted = 0
+                    GROUP BY lecture_id
+                ) rv_avg ON rv_avg.lecture_id = l.lecture_id
+                LEFT JOIN (
+                    SELECT
+                        lr.lecture_id,
+                        GROUP_CONCAT(DISTINCT r.sigungu ORDER BY r.sigungu SEPARATOR ', ') AS preferred_regions
+                    FROM lecture_region lr
+                    JOIN region r ON lr.region_code = r.region_code
+                    GROUP BY lr.lecture_id
+                ) rg ON rg.lecture_id = l.lecture_id
+                WHERE
+                    a.mentee_id = #{menteeId}
+                    AND a.is_deleted = 0
+                    AND l.is_deleted = 0
+                ORDER BY
+                    a.created_at DESC
+            """)
+    List<AppliedLectureResponseDto> findMyAppliedLectures(Long menteeId);
+
+    // 내가 등록한 과외 목록
+    @Select("""
+                SELECT 
+                    l.lecture_id,
+                    l.lecture_title,
+                    l.price,
+                    COALESCE(rv_avg.average_rating, 0) AS average_rating,
+                    rg.preferred_regions,
+                    lc.subcategory,
+                    u.profile_image
+                FROM lecture l
+                LEFT JOIN lecture_category lc ON l.category_id = lc.category_id
+                LEFT JOIN app_user u ON l.mentor_id = u.user_id
+                LEFT JOIN (
+                    SELECT lecture_id, ROUND(AVG(rating), 1) AS average_rating
+                    FROM review
+                    WHERE is_deleted = 0
+                    GROUP BY lecture_id
+                ) rv_avg ON rv_avg.lecture_id = l.lecture_id
+                LEFT JOIN (
+                    SELECT 
+                        lr.lecture_id,
+                        GROUP_CONCAT(DISTINCT r.sigungu ORDER BY r.sigungu SEPARATOR ', ') AS preferred_regions
+                    FROM lecture_region lr
+                    JOIN region r ON lr.region_code = r.region_code
+                    GROUP BY lr.lecture_id
+                ) rg ON rg.lecture_id = l.lecture_id
+                WHERE 
+                    l.mentor_id = #{mentorId}
+                    AND l.is_deleted = 0
+                ORDER BY 
+                    l.created_at DESC
+            """)
+    List<LectureResponseDto> findLecturesByMentorId(Long mentorId);
+
+    // 특정 강의에 대한 신청 리스트
+    @Select("""
+        SELECT
+            a.application_id,
+            u.nickname,
+            l.lecture_title,
+            DATE(a.created_at) AS created_at,
+            u.profile_image
+        FROM application a
+        JOIN app_user u ON a.mentee_id = u.user_id
+        JOIN lecture l ON a.lecture_id = l.lecture_id
+        WHERE
+            l.lecture_id = #{lectureId}
+            AND a.status = 'PENDING'
+            AND a.is_deleted = 0
+        ORDER BY
+            a.created_at DESC
+    """)
+    List<LectureApplicantDto> findApplicantsByLectureId(Long lectureId);
+
+    // 수락 처리
+    @Update("""
+        UPDATE application
+        SET status = 'ACCEPTED', updated_at = CURRENT_TIMESTAMP
+        WHERE application_id = #{applicationId}
+    """)
+    void acceptApplication(Long applicationId);
+
+    // 반려 처리
+    @Update("""
+        UPDATE application
+        SET status = 'REJECTED', updated_at = CURRENT_TIMESTAMP
+        WHERE application_id = #{applicationId}
+    """)
+    void rejectApplication(Long applicationId);
+
+
+
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.feature.application.model.mapper;
 
+import aibe1.proj2.mentoss.feature.application.model.dto.ApplicationInfoDto;
 import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
 import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
 import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
@@ -128,6 +129,21 @@ public interface ApplicationMapper {
     """)
     void rejectApplication(Long applicationId);
 
+    @Select("""
+                SELECT 
+                    a.mentee_id,
+                    l.lecture_title
+                FROM application a
+                JOIN lecture l ON a.lecture_id = l.lecture_id
+                WHERE a.application_id = #{applicationId}
+            """)
+    ApplicationInfoDto findApplicationInfo(Long applicationId);
 
 
+    @Select("""
+                SELECT status
+                FROM application
+                WHERE application_id = #{applicationId}
+            """)
+    String findStatusByApplicationId(Long applicationId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
@@ -1,0 +1,16 @@
+package aibe1.proj2.mentoss.feature.application.service;
+
+import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
+
+import java.util.List;
+
+public interface ApplicationService {
+
+    List<AppliedLectureResponseDto> getMyAppliedLectures(Long menteeId);
+
+    List<LectureResponseDto> getLecturesByMentor(Long mentorId);
+
+    List<LectureApplicantDto> getApplicantsByLectureId(Long lectureId);
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
@@ -13,4 +13,8 @@ public interface ApplicationService {
     List<LectureResponseDto> getLecturesByMentor(Long mentorId);
 
     List<LectureApplicantDto> getApplicantsByLectureId(Long lectureId);
+
+    void approveApplication(Long applicationId, Long senderId);
+
+    void rejectApplication(Long applicationId, String rejectReason , Long senderId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
@@ -1,8 +1,6 @@
 package aibe1.proj2.mentoss.feature.application.service;
 
-import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
-import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
-import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.*;
 
 import java.util.List;
 
@@ -17,4 +15,8 @@ public interface ApplicationService {
     void approveApplication(Long applicationId, Long senderId);
 
     void rejectApplication(Long applicationId, String rejectReason , Long senderId);
+
+    LectureApplyFormDto getLectureApplyForm(Long lectureId);
+
+    void applyForLecture(LectureApplyRequestDto dto, Long menteeId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationServiceImpl.java
@@ -1,11 +1,17 @@
 package aibe1.proj2.mentoss.feature.application.service;
 
+import aibe1.proj2.mentoss.feature.application.model.dto.ApplicationInfoDto;
 import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
 import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
 import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
 import aibe1.proj2.mentoss.feature.application.model.mapper.ApplicationMapper;
+import aibe1.proj2.mentoss.feature.message.model.dto.MessageSendRequestDto;
+import aibe1.proj2.mentoss.feature.message.service.MessageService;
+import aibe1.proj2.mentoss.global.entity.enums.ApplicationStatus;
+import aibe1.proj2.mentoss.global.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -14,6 +20,7 @@ import java.util.List;
 public class ApplicationServiceImpl implements ApplicationService {
 
     private final ApplicationMapper applicationMapper;
+    private final MessageService messageService;
 
     @Override
     public List<AppliedLectureResponseDto> getMyAppliedLectures(Long menteeId) {
@@ -28,5 +35,38 @@ public class ApplicationServiceImpl implements ApplicationService {
     @Override
     public List<LectureApplicantDto> getApplicantsByLectureId(Long lectureId) {
         return applicationMapper.findApplicantsByLectureId(lectureId);
+    }
+
+    @Transactional
+    @Override
+    public void approveApplication(Long applicationId, Long senderId) {
+        ApplicationInfoDto info = validatePendingApplication(applicationId);
+        applicationMapper.acceptApplication(applicationId);
+
+        String content = String.format("'%s' 과외 신청이 수락되었습니다.", info.lectureTitle());
+        messageService.sendMessage(new MessageSendRequestDto(info.menteeId(), content), senderId);
+    }
+
+    @Transactional
+    @Override
+    public void rejectApplication(Long applicationId, String rejectReason, Long senderId) {
+        ApplicationInfoDto info = validatePendingApplication(applicationId);
+        applicationMapper.rejectApplication(applicationId);
+
+        String content = String.format("'%s' 과외 신청이 반려되었습니다.\n사유: %s", info.lectureTitle(), rejectReason);
+        messageService.sendMessage(new MessageSendRequestDto(info.menteeId(), content), senderId);
+    }
+
+    private ApplicationInfoDto validatePendingApplication(Long applicationId) {
+        ApplicationInfoDto info = applicationMapper.findApplicationInfo(applicationId);
+        if (info == null) {
+            throw new ResourceNotFoundException("Application", applicationId);
+        }
+
+        String currentStatus = applicationMapper.findStatusByApplicationId(applicationId);
+        if (!ApplicationStatus.PENDING.name().equals(currentStatus)) {
+            throw new IllegalStateException("이미 처리된 과외 신청입니다.");
+        }
+        return info;
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationServiceImpl.java
@@ -1,0 +1,32 @@
+package aibe1.proj2.mentoss.feature.application.service;
+
+import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.mapper.ApplicationMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationServiceImpl implements ApplicationService {
+
+    private final ApplicationMapper applicationMapper;
+
+    @Override
+    public List<AppliedLectureResponseDto> getMyAppliedLectures(Long menteeId) {
+        return applicationMapper.findMyAppliedLectures(menteeId);
+    }
+
+    @Override
+    public List<LectureResponseDto> getLecturesByMentor(Long mentorId) {
+        return applicationMapper.findLecturesByMentorId(mentorId);
+    }
+
+    @Override
+    public List<LectureApplicantDto> getApplicantsByLectureId(Long lectureId) {
+        return applicationMapper.findApplicantsByLectureId(lectureId);
+    }
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationServiceImpl.java
@@ -1,14 +1,13 @@
 package aibe1.proj2.mentoss.feature.application.service;
 
-import aibe1.proj2.mentoss.feature.application.model.dto.ApplicationInfoDto;
-import aibe1.proj2.mentoss.feature.application.model.dto.AppliedLectureResponseDto;
-import aibe1.proj2.mentoss.feature.application.model.dto.LectureApplicantDto;
-import aibe1.proj2.mentoss.feature.application.model.dto.LectureResponseDto;
+import aibe1.proj2.mentoss.feature.application.model.dto.*;
 import aibe1.proj2.mentoss.feature.application.model.mapper.ApplicationMapper;
 import aibe1.proj2.mentoss.feature.message.model.dto.MessageSendRequestDto;
 import aibe1.proj2.mentoss.feature.message.service.MessageService;
 import aibe1.proj2.mentoss.global.entity.enums.ApplicationStatus;
 import aibe1.proj2.mentoss.global.exception.ResourceNotFoundException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +20,7 @@ public class ApplicationServiceImpl implements ApplicationService {
 
     private final ApplicationMapper applicationMapper;
     private final MessageService messageService;
+    private final ObjectMapper objectMapper;
 
     @Override
     public List<AppliedLectureResponseDto> getMyAppliedLectures(Long menteeId) {
@@ -68,5 +68,60 @@ public class ApplicationServiceImpl implements ApplicationService {
             throw new IllegalStateException("이미 처리된 과외 신청입니다.");
         }
         return info;
+    }
+
+    @Override
+    public LectureApplyFormDto getLectureApplyForm(Long lectureId) {
+        LectureApplyFormRawDto rawDto = applicationMapper.findLectureApplyFormData(lectureId);
+
+        List<TimeSlot> timeSlots;
+        try {
+            timeSlots = objectMapper.readValue(
+                    rawDto.availableTimeSlots(),
+                    objectMapper.getTypeFactory().constructCollectionType(List.class, TimeSlot.class)
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("시간 정보 파싱 실패", e);
+        }
+
+        return new LectureApplyFormDto(
+                rawDto.lectureId(),
+                rawDto.lectureTitle(),
+                timeSlots,
+                rawDto.profileImage(),
+                rawDto.nickname(),
+                rawDto.education(),
+                rawDto.major(),
+                rawDto.isCertified(),
+                rawDto.averageRating()
+        );
+    }
+
+    @Override
+    @Transactional
+    public void applyForLecture(LectureApplyRequestDto dto, Long menteeId) {
+        String timeSlotsJson;
+        try {
+            timeSlotsJson = objectMapper.writeValueAsString(dto.requestedTimeSlots());
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("요청 시간대를 처리하는 중 오류 발생: " + e.getMessage());
+        }
+
+        applicationMapper.insertApplication(dto.lectureId(), menteeId, timeSlotsJson);
+
+        // 3. 쪽지 전송
+        LectureSimpleInfoDto info = applicationMapper.findLectureSimpleInfo(dto.lectureId());
+        if (info == null) {
+            throw new ResourceNotFoundException("Lecture", dto.lectureId());
+        }
+
+        String content = dto.message() == null || dto.message().trim().isEmpty()
+                ? String.format("'%s' 과외 신청을 보냈습니다.", info.lectureTitle())
+                : String.format("'%s' 과외 신청을 보냈습니다.\n%s", info.lectureTitle(), dto.message());
+
+        messageService.sendMessage(
+                new MessageSendRequestDto(info.mentorId(), content),
+                menteeId
+        );
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/message/controller/MessageController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/message/controller/MessageController.java
@@ -2,6 +2,7 @@ package aibe1.proj2.mentoss.feature.message.controller;
 
 import aibe1.proj2.mentoss.feature.message.model.dto.MessageResponseDto;
 import aibe1.proj2.mentoss.feature.message.model.dto.MessageSendRequestDto;
+import aibe1.proj2.mentoss.feature.message.model.dto.PageResponse;
 import aibe1.proj2.mentoss.feature.message.service.MessageService;
 import aibe1.proj2.mentoss.global.dto.ApiResponseFormat;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,17 +28,23 @@ public class MessageController {
 
     @Operation(summary = "보낸 편지함 조회", description = "현재 로그인한 사용자가 보낸 메시지를 조회합니다.")
     @GetMapping("/sent")
-    public ResponseEntity<ApiResponseFormat<List<MessageResponseDto>>> getSentMessages(Authentication authentication) {
-//        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
-        List<MessageResponseDto> messages = messageService.getSentMessages(userId);
-        return ResponseEntity.ok(ApiResponseFormat.ok(messages));
+    public ResponseEntity<ApiResponseFormat<PageResponse<MessageResponseDto>>> getSentMessages(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageResponse<MessageResponseDto> response = messageService.getSentMessages(userId, page, size);
+        return ResponseEntity.ok(ApiResponseFormat.ok(response));
     }
 
     @Operation(summary = "받은 편지함 조회", description = "현재 로그인한 사용자가 받은 메시지를 조회합니다.")
     @GetMapping("/received")
-    public ResponseEntity<ApiResponseFormat<List<MessageResponseDto>>> getReceivedMessages(Authentication authentication) {
-        List<MessageResponseDto> messages = messageService.getReceivedMessages(userId);
-        return ResponseEntity.ok(ApiResponseFormat.ok(messages));
+    public ResponseEntity<ApiResponseFormat<PageResponse<MessageResponseDto>>> getReceivedMessages(
+            Authentication authentication,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        PageResponse<MessageResponseDto> response = messageService.getReceivedMessages(userId, page, size);
+        return ResponseEntity.ok(ApiResponseFormat.ok(response));
     }
 
     @Operation(summary = "쪽지 조회", description = "쪽지 ID를 통해 쪽지를 조회합니다.")

--- a/src/main/java/aibe1/proj2/mentoss/feature/message/model/dto/MessageSendRequestDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/message/model/dto/MessageSendRequestDto.java
@@ -3,7 +3,6 @@ package aibe1.proj2.mentoss.feature.message.model.dto;
 import aibe1.proj2.mentoss.global.entity.Message;
 
 public record MessageSendRequestDto(
-
         Long receiverId,
         String content
 ) {

--- a/src/main/java/aibe1/proj2/mentoss/feature/message/model/dto/PageResponse.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/message/model/dto/PageResponse.java
@@ -1,0 +1,16 @@
+package aibe1.proj2.mentoss.feature.message.model.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        int totalPages,
+        long totalCount
+) {
+    public static <T> PageResponse<T> of(List<T> content, int page, int size, long totalCount) {
+        int totalPages = (int) Math.ceil((double) totalCount / size);
+        return new PageResponse<>(content, page, size, totalPages, totalCount);
+    }
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/message/model/mapper/MessageMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/message/model/mapper/MessageMapper.java
@@ -14,16 +14,30 @@ public interface MessageMapper {
     @Select("""
                 SELECT * FROM message
                 WHERE sender_id = #{userId} AND is_deleted = 0
-                ORDER BY created_at DESC
+                ORDER BY message_id DESC
+                LIMIT #{limit} OFFSET #{offset}
             """)
-    List<Message> findSentMessages(Long userId);
+    List<Message> findSentMessages(Long userId, int limit, int offset);
 
     @Select("""
                 SELECT * FROM message
                 WHERE receiver_id = #{userId} AND is_deleted = 0
-                ORDER BY created_at DESC
+                ORDER BY message_id DESC
+                LIMIT #{limit} OFFSET #{offset}
             """)
-    List<Message> findReceivedMessages(Long userId);
+    List<Message> findReceivedMessages(Long userId, int limit, int offset);
+
+    @Select("""
+                SELECT COUNT(*) FROM message
+                WHERE sender_id = #{userId} AND is_deleted = 0
+            """)
+    int countSentMessages(Long userId);
+
+    @Select("""
+                SELECT COUNT(*) FROM message
+                WHERE receiver_id = #{userId} AND is_deleted = 0
+            """)
+    int countReceivedMessages(Long userId);
 
 
     @Select("SELECT * FROM message WHERE message_id = #{id} AND is_deleted = 0")

--- a/src/main/java/aibe1/proj2/mentoss/feature/message/service/MessageService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/message/service/MessageService.java
@@ -2,14 +2,15 @@ package aibe1.proj2.mentoss.feature.message.service;
 
 import aibe1.proj2.mentoss.feature.message.model.dto.MessageResponseDto;
 import aibe1.proj2.mentoss.feature.message.model.dto.MessageSendRequestDto;
+import aibe1.proj2.mentoss.feature.message.model.dto.PageResponse;
 
 import java.util.List;
 
 public interface MessageService {
 
-    List<MessageResponseDto> getSentMessages(Long senderId);
+    PageResponse<MessageResponseDto> getSentMessages(Long senderId, int page, int size);;
 
-    List<MessageResponseDto> getReceivedMessages(Long receiverId);
+    PageResponse<MessageResponseDto> getReceivedMessages(Long receiverId, int page, int size);
 
     MessageResponseDto getMessage(Long messageId, Long viewerId);
 

--- a/src/main/java/aibe1/proj2/mentoss/feature/message/service/MessageServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/message/service/MessageServiceImpl.java
@@ -2,6 +2,7 @@ package aibe1.proj2.mentoss.feature.message.service;
 
 import aibe1.proj2.mentoss.feature.message.model.dto.MessageResponseDto;
 import aibe1.proj2.mentoss.feature.message.model.dto.MessageSendRequestDto;
+import aibe1.proj2.mentoss.feature.message.model.dto.PageResponse;
 import aibe1.proj2.mentoss.feature.message.model.mapper.MessageMapper;
 import aibe1.proj2.mentoss.global.entity.Message;
 import lombok.AllArgsConstructor;
@@ -16,19 +17,28 @@ public class MessageServiceImpl implements MessageService{
     private final MessageMapper messageMapper;
 
     @Override
-    public List<MessageResponseDto> getSentMessages(Long senderId) {
-        List<Message> messages = messageMapper.findSentMessages(senderId);
-        return messages.stream()
-                .map(message -> MessageResponseDto.fromEntity(message, senderId))
+    public PageResponse<MessageResponseDto> getSentMessages(Long senderId, int page, int size) {
+        int offset = (page - 1) * size;
+        List<Message> messages = messageMapper.findSentMessages(senderId, size, offset);
+        int totalCount = messageMapper.countSentMessages(senderId);
+
+        List<MessageResponseDto> content = messages.stream()
+                .map(m -> MessageResponseDto.fromEntity(m, senderId))
                 .toList();
+
+        return PageResponse.of(content, page, size, totalCount);
     }
 
     @Override
-    public List<MessageResponseDto> getReceivedMessages(Long receiverId) {
-        List<Message> messages = messageMapper.findReceivedMessages(receiverId);
-        return messages.stream()
+    public PageResponse<MessageResponseDto> getReceivedMessages(Long receiverId, int page, int size) {
+        int offset = (page - 1) * size;
+        List<Message> messages = messageMapper.findReceivedMessages(receiverId, size, offset);
+        int totalCount = messageMapper.countSentMessages(receiverId);
+
+        List<MessageResponseDto> content = messages.stream()
                 .map(message -> MessageResponseDto.fromEntity(message, receiverId))
                 .toList();
+        return PageResponse.of(content, page, size, totalCount);
     }
 
     @Override


### PR DESCRIPTION

## 개인 기능 추가
1. 과외 문의 기능
/api/application/apply/list: 내가 신청한 과외 목록 조회
/api/application/apply/lectures/list: 내가 등록한 과외 목록 조회
/api/application/{lectureId}/applicants: 특정 강의에 신청한 멘티 목록 조회
/api/application/approve: 신청 수락 처리
/api/application/reject: 신청 반려 처리

2. 쪽지 연동 로직
신청 수락 시: 수락 메시지 자동 전송
신청 반려 시: 반려 사유 포함 메시지 자동 전송

모두 Transactional 처리로 DB와 메시지 동기화 보장

3. 과외 신청 기능
/api/application/{lectureId}/form/list: 과외 신청 폼 조회
/api/application/apply: 과외 신청 요청 처리

## 공용 기능 추가
global은 추가/수정한 부분은 없습니다..