### PR TITLE
🔐 fix: /api/ping 경로를 Spring Security에서 permitAll로 설정

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/global/config/SecurityConfig.java
+++ b/src/main/java/aibe1/proj2/mentoss/global/config/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
                 // 요청에 대한 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 공개 API 엔드포인트
-                        .requestMatchers("/test/**", "/api/test/**", "/api/auth/test/public", "/oauth2/**", "/login/**", "/css/**", "/js/**", "/images/**").permitAll()
+                        .requestMatchers("/test/**", "/api/test/**", "/api/auth/test/public", "/oauth2/**", "/login/**", "/css/**", "/js/**", "/images/**", "/api/ping").permitAll()
                         // 관리자만 접근 가능한 엔드포인트
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         // 인증된 사용자만 접근 가능한 나머지 엔드포인트


### PR DESCRIPTION
- ping API는 서버 슬립 방지를 위해 GitHub Actions, UptimeRobot 등 외부에서 접근됨
- 인증 없이 접근 가능해야 하므로 /api/ping 엔드포인트에 permitAll() 추가