### PR TITLE
feat: 프로필 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
@@ -8,9 +8,13 @@ import aibe1.proj2.mentoss.global.dto.ApiResponseFormat;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "Account API", description = "회원 계정 관련 API")
 @RestController
@@ -57,5 +61,16 @@ public class AccountController {
         Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
         accountService.deleteAccount(userId);
         return ResponseEntity.ok(ApiResponseFormat.ok(null));
+    }
+
+    @Operation(summary = "프로필 이미지 업로드", description = "사용자의 프로필 이미지를 업로드 합니다")
+    @PostMapping(value = "/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponseFormat<String>> uploadProfileImage(
+            Authentication authentication,
+            @RequestParam("file") MultipartFile file
+    ) throws IOException {
+        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        String imageUrl = accountService.updateProfileImage(userId, file);
+        return ResponseEntity.ok(ApiResponseFormat.ok(imageUrl));
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/AccountMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/AccountMapper.java
@@ -57,4 +57,10 @@ public interface AccountMapper {
             "deleted_at = #{deletedAt} " +
             "WHERE user_id = #{userId}")
     void softDeleteUser(AppUser appUser);
+
+    @Update("UPDATE app_user SET " +
+            "profile_image = #{profileImage}, " +
+            "updated_at = NOW() " +
+            "WHERE user_id = #{userId}")
+    void updateProfileImage(@Param("userId") Long userId, @Param("profileImage") String profileImage);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
@@ -2,6 +2,9 @@ package aibe1.proj2.mentoss.feature.account.service;
 
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 public interface AccountService {
 
@@ -14,4 +17,6 @@ public interface AccountService {
     boolean isProfileCompleted(Long userId);
 
     void deleteAccount(Long userId);
+
+    String updateProfileImage(Long userId, MultipartFile file) throws IOException;
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/file/service/FileService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/file/service/FileService.java
@@ -7,4 +7,6 @@ import java.io.IOException;
 public interface FileService {
 
     String uploadFile(MultipartFile file, String directoryPath) throws IOException;
+
+    boolean deleteFile(String fileUrl);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/file/service/FileService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/file/service/FileService.java
@@ -1,0 +1,10 @@
+package aibe1.proj2.mentoss.feature.file.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileService {
+
+    String uploadFile(MultipartFile file, String directoryPath) throws IOException;
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/file/service/R2FileServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/file/service/R2FileServiceImpl.java
@@ -1,0 +1,58 @@
+package aibe1.proj2.mentoss.feature.file.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class R2FileServiceImpl implements FileService {
+
+    private final S3Client r2Client;
+
+    @Value("${cloudflare.r2.bucket}")
+    private String bucketName;
+
+    @Value("${cloudflare.r2.public-url}")
+    private String publicUrl;
+
+    @Override
+    public String uploadFile(MultipartFile file, String directoryPath) throws IOException {
+
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("빈 파일은 업로드 할 수 없습니다");
+        }
+
+        // 파일 확장자 추출
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+
+        // 저장 경로 및 파일명 생성 (UUID 사용)
+        String folder = (directoryPath != null && !directoryPath.isEmpty()) ? directoryPath : "uploads";
+        String fileName = UUID.randomUUID().toString() + extension;
+        String key = folder + "/" + fileName;
+
+        // S3 업로드 요청 생성
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(file.getContentType())
+                .build();
+
+        r2Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
+
+        return publicUrl + "/" + key;
+    }
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/file/service/R2FileServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/file/service/R2FileServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -54,5 +55,34 @@ public class R2FileServiceImpl implements FileService {
         r2Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
 
         return publicUrl + "/" + key;
+    }
+
+    @Override
+    public boolean deleteFile(String fileUrl) {
+
+        if (fileUrl == null || !fileUrl.startsWith(publicUrl)) {
+            return false;
+        }
+
+        String key;
+
+        try {
+            if (fileUrl.length() > publicUrl.length() + 1) {
+                key = fileUrl.substring(publicUrl.length() + 1);
+            } else {
+                return false;
+            }
+
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            r2Client.deleteObject(request);
+            return true;
+        } catch (Exception e) {
+            log.error("파일 삭제 중 오류 발생: {}", e.getMessage(), e);
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## 📌 PR 내용
파일 업로드 서비스 구현 및 프로필 이미지 업로드 기능을 구현했습니다

## 🔨 구현 기능
- 파일 업로드 서비스 인터페이스 및 Cloudflare R2 구현체 개발
  - UUID를 사용하여 고유한 파일명 생성
  - 파일 타입 감지 및 확장자 유지
  - R2 스토리지를 활용한 업로드 및 삭제 구현
- 파일 삭제 기능 구현
  - 기존 이미지가 있을 경우 자동으로 삭제하고 새 이미지로 대체
- 프로필 이미지 업데이트 기능 구현 (AccountMapper, AccountService)
- 프로필 이미지 업로드 API 엔드포인트 구현 (AccountController)

## 📢 특이사항
- 서버 상태에 따라 Cloudflare R2 파일 처리가 지연될 수 있음