### PR TITLE
feat: 멘토 프로필 관련 API 구현

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.controller;
 
+import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
 import aibe1.proj2.mentoss.feature.account.service.AccountService;
@@ -82,5 +83,15 @@ public class AccountController {
         Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
         boolean isMentor = accountService.isMentor(userId);
         return ResponseEntity.ok(ApiResponseFormat.ok(isMentor));
+    }
+
+    @Operation(summary = "멘토 프로필 조회", description = "사용자의 멘토 프로필을 조회합니다")
+    @GetMapping("/mentor/profile")
+    public ResponseEntity<ApiResponseFormat<MentorProfileResponseDto>> getMentorProfile(
+            Authentication authentication
+    ) {
+        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        MentorProfileResponseDto mentorProfile = accountService.getMentorProfile(userId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(mentorProfile));
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
@@ -106,4 +106,15 @@ public class AccountController {
         accountService.applyMentorProfile(userId, requestDto);
         return ResponseEntity.ok(ApiResponseFormat.ok(null));
     }
+
+    @Operation(summary = "멘토 프로필 업데이트", description = "멘토 프로필 정보를 업데이트합니다")
+    @PutMapping(value = "/mentor/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponseFormat<Void>> updateMentorProfile(
+            Authentication authentication,
+            @ModelAttribute MentorProfileRequestDto requestDto
+    ) throws IOException {
+        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        accountService.updateMentorProfile(userId, requestDto);
+        return ResponseEntity.ok(ApiResponseFormat.ok(null));
+    }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.controller;
 
+import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileRequestDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
@@ -93,5 +94,16 @@ public class AccountController {
         Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
         MentorProfileResponseDto mentorProfile = accountService.getMentorProfile(userId);
         return ResponseEntity.ok(ApiResponseFormat.ok(mentorProfile));
+    }
+
+    @Operation(summary = "멘토 신청", description = "멘토 프로필을 생성하고 역할을 업데이트합니다")
+    @PostMapping(value = "/mentor/apply", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponseFormat<Void>> applyMentorProfile(
+            Authentication authentication,
+            @ModelAttribute MentorProfileRequestDto requestDto
+    ) throws IOException {
+        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        accountService.applyMentorProfile(userId, requestDto);
+        return ResponseEntity.ok(ApiResponseFormat.ok(null));
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
@@ -73,4 +73,14 @@ public class AccountController {
         String imageUrl = accountService.updateProfileImage(userId, file);
         return ResponseEntity.ok(ApiResponseFormat.ok(imageUrl));
     }
+
+    @Operation(summary = "멘토 여부 확인", description = "사용자가 멘토인지 확인합니다")
+    @GetMapping("/mentor/check")
+    public ResponseEntity<ApiResponseFormat<Boolean>> isMentor(
+            Authentication authentication
+    ) {
+        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        boolean isMentor = accountService.isMentor(userId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(isMentor));
+    }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
@@ -1,9 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.controller;
 
-import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileRequestDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
+import aibe1.proj2.mentoss.feature.account.model.dto.*;
 import aibe1.proj2.mentoss.feature.account.service.AccountService;
 import aibe1.proj2.mentoss.global.auth.CustomUserDetails;
 import aibe1.proj2.mentoss.global.dto.ApiResponseFormat;
@@ -116,5 +113,15 @@ public class AccountController {
         Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
         accountService.updateMentorProfile(userId, requestDto);
         return ResponseEntity.ok(ApiResponseFormat.ok(null));
+    }
+
+    @Operation(summary = "멘토 상태 확인", description = "멘토의 인증 상태를 확인합니다")
+    @GetMapping("/mentor/status")
+    public ResponseEntity<ApiResponseFormat<MentorStatusResponseDto>> getMentorStatus(
+            Authentication authentication
+    ) {
+        Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
+        MentorStatusResponseDto mentorStatus = accountService.getMentorStatus(userId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(mentorStatus));
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/dto/MentorProfileRequestDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/dto/MentorProfileRequestDto.java
@@ -1,0 +1,9 @@
+package aibe1.proj2.mentoss.feature.account.model.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record MentorProfileRequestDto (
+        String content,
+        MultipartFile appealFile
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/dto/MentorProfileResponseDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/dto/MentorProfileResponseDto.java
@@ -1,0 +1,31 @@
+package aibe1.proj2.mentoss.feature.account.model.dto;
+
+import aibe1.proj2.mentoss.global.entity.MentorProfile;
+
+import java.time.LocalDateTime;
+
+public record MentorProfileResponseDto(
+        Long mentorId,
+        Long userId,
+        String education,
+        String major,
+        Boolean isCertified,
+        String content,
+        String appealFileUrl,
+        String tag,
+        LocalDateTime createdAt
+) {
+    public static MentorProfileResponseDto fromEntity(MentorProfile mentorProfile) {
+        return new MentorProfileResponseDto(
+                mentorProfile.getMentorId(),
+                mentorProfile.getUserId(),
+                mentorProfile.getEducation(),
+                mentorProfile.getMajor(),
+                mentorProfile.getIsCertified(),
+                mentorProfile.getContent(),
+                mentorProfile.getAppealFileUrl(),
+                mentorProfile.getTag(),
+                mentorProfile.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/dto/MentorStatusResponseDto.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/dto/MentorStatusResponseDto.java
@@ -1,0 +1,7 @@
+package aibe1.proj2.mentoss.feature.account.model.dto;
+
+public record MentorStatusResponseDto(
+        boolean isMentor,
+        boolean isCertified
+) {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/MentorMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/MentorMapper.java
@@ -1,8 +1,7 @@
 package aibe1.proj2.mentoss.feature.account.model.mapper;
 
 import aibe1.proj2.mentoss.global.entity.MentorProfile;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -18,4 +17,14 @@ public interface MentorMapper {
     @Select("SELECT COUNT(*) > 0 FROM mentor_profile " +
             "WHERE user_id = #{userId}")
     boolean existsByUserId(Long userId);
+
+    @Insert("INSERT INTO mentor_profile " +
+            "(user_id, content, appeal_file_url, is_certified, created_at) " +
+            "VALUES (#{userId}, #{content}, #{appealFileUrl}, #{isCertified}, #{createdAt})")
+    @Options(useGeneratedKeys = true, keyProperty = "mentorId")
+    int insertMentorProfile(MentorProfile mentorProfile);
+
+    @Update("UPDATE app_user SET role = 'MENTOR' " +
+            "WHERE user_id = #{userId}")
+    int updateToMentorRole(Long userId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/MentorMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/MentorMapper.java
@@ -27,4 +27,11 @@ public interface MentorMapper {
     @Update("UPDATE app_user SET role = 'MENTOR' " +
             "WHERE user_id = #{userId}")
     int updateToMentorRole(Long userId);
+
+
+    @Update("UPDATE mentor_profile SET " +
+            "content = #{content}, " +
+            "appeal_file_url = #{appealFileUrl} " +
+            "WHERE user_id = #{userId}")
+    int updateMentorProfile(MentorProfile mentorProfile);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/MentorMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/MentorMapper.java
@@ -1,0 +1,21 @@
+package aibe1.proj2.mentoss.feature.account.model.mapper;
+
+import aibe1.proj2.mentoss.global.entity.MentorProfile;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Mapper
+@Repository
+public interface MentorMapper {
+
+    @Select("SELECT * FROM mentor_profile " +
+            "WHERE user_id = #{userId}")
+    Optional<MentorProfile> findByUserId(Long userId);
+
+    @Select("SELECT COUNT(*) > 0 FROM mentor_profile " +
+            "WHERE user_id = #{userId}")
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.service;
 
+import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileRequestDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
@@ -24,4 +25,6 @@ public interface AccountService {
     boolean isMentor(Long userId);
 
     MentorProfileResponseDto getMentorProfile(Long userId);
+
+    void applyMentorProfile(Long userId, MentorProfileRequestDto requestDto) throws IOException;
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
@@ -19,4 +19,6 @@ public interface AccountService {
     void deleteAccount(Long userId);
 
     String updateProfileImage(Long userId, MultipartFile file) throws IOException;
+
+    boolean isMentor(Long userId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
@@ -1,9 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.service;
 
-import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileRequestDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
+import aibe1.proj2.mentoss.feature.account.model.dto.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -30,4 +27,5 @@ public interface AccountService {
 
     void updateMentorProfile(Long userId, MentorProfileRequestDto requestDto) throws IOException;
 
+    MentorStatusResponseDto getMentorStatus(Long userId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.service;
 
+import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,4 +22,6 @@ public interface AccountService {
     String updateProfileImage(Long userId, MultipartFile file) throws IOException;
 
     boolean isMentor(Long userId);
+
+    MentorProfileResponseDto getMentorProfile(Long userId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountService.java
@@ -27,4 +27,7 @@ public interface AccountService {
     MentorProfileResponseDto getMentorProfile(Long userId);
 
     void applyMentorProfile(Long userId, MentorProfileRequestDto requestDto) throws IOException;
+
+    void updateMentorProfile(Long userId, MentorProfileRequestDto requestDto) throws IOException;
+
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
@@ -3,6 +3,7 @@ package aibe1.proj2.mentoss.feature.account.service;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
 import aibe1.proj2.mentoss.feature.account.model.mapper.AccountMapper;
+import aibe1.proj2.mentoss.feature.account.model.mapper.MentorMapper;
 import aibe1.proj2.mentoss.feature.file.service.FileService;
 import aibe1.proj2.mentoss.global.entity.AppUser;
 import aibe1.proj2.mentoss.global.entity.Region;
@@ -26,6 +27,7 @@ public class AccountServiceImpl implements AccountService {
 
     private final AccountMapper accountMapper;
     private final FileService fileService;
+    private final MentorMapper mentorMapper;
 
     @Override
     public ProfileResponseDto getProfile(Long userId) {
@@ -129,5 +131,10 @@ public class AccountServiceImpl implements AccountService {
         accountMapper.updateProfileImage(userId, imageUrl);
 
         return imageUrl;
+    }
+
+    @Override
+    public boolean isMentor(Long userId) {
+        return mentorMapper.existsByUserId(userId);
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.service;
 
+import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileRequestDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
@@ -146,5 +147,29 @@ public class AccountServiceImpl implements AccountService {
                 .orElseThrow(() -> new ResourceNotFoundException("MentorProfile", userId));
 
         return MentorProfileResponseDto.fromEntity(mentorProfile);
+    }
+
+    @Override
+    @Transactional
+    public void applyMentorProfile(Long userId, MentorProfileRequestDto requestDto) throws IOException {
+        if (mentorMapper.existsByUserId(userId)) {
+            throw new IllegalArgumentException("이미 멘토 신청을 하였습니다");
+        }
+
+        String appealFileUrl = null;
+        if (requestDto.appealFile() != null && !requestDto.appealFile().isEmpty()) {
+            appealFileUrl = fileService.uploadFile(requestDto.appealFile(), "mentor-appeals");
+        }
+
+        MentorProfile mentorProfile = MentorProfile.builder()
+                .userId(userId)
+                .content(requestDto.content())
+                .appealFileUrl(appealFileUrl)
+                .isCertified(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        mentorMapper.insertMentorProfile(mentorProfile);
+        mentorMapper.updateToMentorRole(userId);
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
@@ -1,11 +1,13 @@
 package aibe1.proj2.mentoss.feature.account.service;
 
+import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
 import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
 import aibe1.proj2.mentoss.feature.account.model.mapper.AccountMapper;
 import aibe1.proj2.mentoss.feature.account.model.mapper.MentorMapper;
 import aibe1.proj2.mentoss.feature.file.service.FileService;
 import aibe1.proj2.mentoss.global.entity.AppUser;
+import aibe1.proj2.mentoss.global.entity.MentorProfile;
 import aibe1.proj2.mentoss.global.entity.Region;
 import aibe1.proj2.mentoss.global.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -136,5 +138,13 @@ public class AccountServiceImpl implements AccountService {
     @Override
     public boolean isMentor(Long userId) {
         return mentorMapper.existsByUserId(userId);
+    }
+
+    @Override
+    public MentorProfileResponseDto getMentorProfile(Long userId) {
+        MentorProfile mentorProfile = mentorMapper.findByUserId(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("MentorProfile", userId));
+
+        return MentorProfileResponseDto.fromEntity(mentorProfile);
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
@@ -1,9 +1,6 @@
 package aibe1.proj2.mentoss.feature.account.service;
 
-import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileRequestDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.MentorProfileResponseDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.ProfileResponseDto;
-import aibe1.proj2.mentoss.feature.account.model.dto.ProfileUpdateRequestDto;
+import aibe1.proj2.mentoss.feature.account.model.dto.*;
 import aibe1.proj2.mentoss.feature.account.model.mapper.AccountMapper;
 import aibe1.proj2.mentoss.feature.account.model.mapper.MentorMapper;
 import aibe1.proj2.mentoss.feature.file.service.FileService;
@@ -156,6 +153,10 @@ public class AccountServiceImpl implements AccountService {
             throw new IllegalArgumentException("이미 멘토 신청을 하였습니다");
         }
 
+        if (requestDto.content() == null || requestDto.content().length() < 10) {
+            throw new IllegalArgumentException("자기소개는 최소 10자 이상 작성해주세요");
+        }
+
         String appealFileUrl = null;
         if (requestDto.appealFile() != null && !requestDto.appealFile().isEmpty()) {
             appealFileUrl = fileService.uploadFile(requestDto.appealFile(), "mentor-appeals");
@@ -178,6 +179,10 @@ public class AccountServiceImpl implements AccountService {
         MentorProfile mentorProfile = mentorMapper.findByUserId(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("MentorProfile", userId));
 
+        if (requestDto.content() == null || requestDto.content().length() < 10) {
+            throw new IllegalArgumentException("자기소개는 최소 10자 이상 작성해주세요");
+        }
+
         String appealFileUrl = null;
         if (requestDto.appealFile() != null && !requestDto.appealFile().isEmpty()){
             if (mentorProfile.getAppealFileUrl() != null && !mentorProfile.getAppealFileUrl().isEmpty()) {
@@ -190,5 +195,19 @@ public class AccountServiceImpl implements AccountService {
 
         mentorProfile.setContent(requestDto.content());
         mentorMapper.updateMentorProfile(mentorProfile);
+    }
+
+    @Override
+    public MentorStatusResponseDto getMentorStatus(Long userId) {
+        boolean isMentor = mentorMapper.existsByUserId(userId);
+        boolean isCertified = false;
+
+        if (isMentor) {
+            MentorProfile mentorProfile = mentorMapper.findByUserId(userId)
+                    .orElseThrow(() -> new ResourceNotFoundException("MentorProfile", userId));
+            isCertified = mentorProfile.getIsCertified();
+        }
+
+        return new MentorStatusResponseDto(isMentor, isCertified);
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
@@ -172,4 +172,23 @@ public class AccountServiceImpl implements AccountService {
         mentorMapper.insertMentorProfile(mentorProfile);
         mentorMapper.updateToMentorRole(userId);
     }
+
+    @Override
+    public void updateMentorProfile(Long userId, MentorProfileRequestDto requestDto) throws IOException {
+        MentorProfile mentorProfile = mentorMapper.findByUserId(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("MentorProfile", userId));
+
+        String appealFileUrl = null;
+        if (requestDto.appealFile() != null && !requestDto.appealFile().isEmpty()){
+            if (mentorProfile.getAppealFileUrl() != null && !mentorProfile.getAppealFileUrl().isEmpty()) {
+                fileService.deleteFile(mentorProfile.getAppealFileUrl());
+            }
+
+            appealFileUrl = fileService.uploadFile(requestDto.appealFile(), "mentor-appeals");
+            mentorProfile.setAppealFileUrl(appealFileUrl);
+        }
+
+        mentorProfile.setContent(requestDto.content());
+        mentorMapper.updateMentorProfile(mentorProfile);
+    }
 }


### PR DESCRIPTION
## 📌 PR 내용

멘토 프로필 관련 API 기능을 구현했습니다

## 🔨 구현 기능

- 멘토 여부 확인 API 구현 (MentorMapper, AccountService)
  - 사용자가 멘토인지 여부를 확인하는 기능
- 멘토 프로필 조회 API 구현
  - MentorProfileResponseDto 생성
  - 사용자의 멘토 프로필 정보 조회 기능
- 멘토 신청 API 구현
  - MentorProfileRequestDto 생성 
  - 멘토 프로필 저장 및 사용자 역할 업데이트 로직 구현
  - 어필 파일 업로드 처리
- 멘토 프로필 업데이트 API 구현
  - 기존 프로필 정보 업데이트 및 파일 교체 처리
  - 업데이트 엔드포인트 구현
- 멘토 상태 확인 API 구현
  - 멘토 여부와 인증 상태를 함께 반환하는 API 추가
  - 멘토 프로필 등록/수정 시 자기소개 최소 글자수 검증 로직 추가