### PR TITLE
fix:region 매퍼 충돌 수정

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/category/model/dto/CategoryResponse.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/category/model/dto/CategoryResponse.java
@@ -1,0 +1,4 @@
+package aibe1.proj2.mentoss.feature.category.model.dto;
+
+public record CategoryResponse() {
+}

--- a/src/main/java/aibe1/proj2/mentoss/feature/region/model/mapper/RegionMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/region/model/mapper/RegionMapper.java
@@ -17,10 +17,13 @@ public interface RegionMapper {
     @Select("SELECT DISTINCT sigungu FROM region WHERE sido = #{sido} ORDER BY sigungu")
     List<String> findSigungusBySido(String sido);
 
-    @Select("SELECT region_code AS regionCode, sido, sigungu, dong " +
+    @Select("SELECT region_code AS regionCode, sido, sigungu, COALESCE(dong, '') AS dong, " +
+            "CONCAT(sido, ' ', sigungu, ' ', COALESCE(dong, '')) AS displayName " +
             "FROM region WHERE sido = #{sido} AND sigungu = #{sigungu} ORDER BY dong")
     List<RegionDto> findDongsBySidoAndSigungu(String sido, String sigungu);
 
-    @Select("SELECT region_code AS regionCode, sido, sigungu, dong FROM region")
+    @Select("SELECT region_code AS regionCode, sido, sigungu, COALESCE(dong, '') AS dong, " +
+            "CONCAT(sido, ' ', sigungu, ' ', COALESCE(dong, '')) AS displayName " +
+            "FROM region")
     List<RegionDto> findAllRegions();
 }


### PR DESCRIPTION
public record RegionDto(
        String regionCode,
        String sido,
        String sigungu,
        String dong,
        String displayName  // 화면에 보여줄 텍스트 (e.g., "서울특별시 강남구 일원동")
) {}

이 버전으로 제가 커밋 푸쉬했다가 

public record RegionDto(
        String regionCode,
        String sido,
        String sigungu,
        String dong,
) {}

제가 이걸로변경하여 사용중이였는데  커밋과 푸쉬를 안하고 작업하다  팀원이랑 꼬여버린것같습니다 
그래서  프론트 api연동할때 충돌이 난것같아요 

충돌안나게 mapper 조금 수정했습니다 
