### PR TITLE
fix: 카카오 로그인 인증 방식 및 리다이렉트 설정 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,12 +25,13 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: email, profile
+            redirect-uri: "https://mentoss.onrender.com/login/oauth2/code/google"
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: "https://mentoss.onrender.com/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
-            client-authentication-method: POST
+            client-authentication-method: client_secret_post
             client-name: Kakao
             scope: profile_nickname, profile_image, account_email
         provider:
@@ -39,6 +40,10 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
 jwt:
   secret: ${JWT_SECRET_KEY}
   expiration-ms: 3600000  # 토큰 유효 시간 (1시간)


### PR DESCRIPTION
# 📌 PR 내용
Spring Security 버전 호환성 문제로 인한 카카오 로그인 오류 수정
## 🔨 수정 사항
- 카카오 OAuth2 인증 방식 수정
  - client-authentication-method: POST를 client_secret_post로 변경하여 Spring Security 6.4.5 버전과 호환되도록 수정