### PR TITLE
feat: 사용자 닉네임 중복 방지 기능 구현

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
@@ -4,6 +4,7 @@ import aibe1.proj2.mentoss.feature.account.model.dto.*;
 import aibe1.proj2.mentoss.feature.account.model.mapper.AccountMapper;
 import aibe1.proj2.mentoss.feature.account.model.mapper.MentorMapper;
 import aibe1.proj2.mentoss.feature.lecture.model.mapper.LectureMapper;
+import aibe1.proj2.mentoss.feature.login.model.mapper.AppUserMapper;
 import aibe1.proj2.mentoss.feature.message.model.mapper.MessageMapper;
 import aibe1.proj2.mentoss.feature.region.model.dto.RegionDto;
 import aibe1.proj2.mentoss.global.entity.AppUser;
@@ -33,6 +34,7 @@ public class AccountServiceImpl implements AccountService {
     private final MentorMapper mentorMapper;
     private final LectureMapper lectureMapper;
     private final MessageMapper messageMapper;
+    private final AppUserMapper appUserMapper;
 
     @Override
     public ProfileResponseDto getProfile(Long userId) {
@@ -49,6 +51,12 @@ public class AccountServiceImpl implements AccountService {
     public void updateProfile(Long userId, ProfileUpdateRequestDto requestDto) {
         AppUser appUser = accountMapper.findByUserId(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("AppUser", userId));
+
+        if (!appUser.getNickname().equals(requestDto.nickname())
+                && appUserMapper.nicknameExists(requestDto.nickname())){
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다. 다른 닉네임을 선택해주세요.");
+
+        }
 
         Long age = calculateAge(requestDto.birthDate());
 

--- a/src/main/java/aibe1/proj2/mentoss/feature/login/model/mapper/AppUserMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/login/model/mapper/AppUserMapper.java
@@ -31,4 +31,7 @@ public interface AppUserMapper {
             "WHERE user_id = #{userId}")
     int update(AppUser appUser);
 
+    @Select("SELECT COUNT(*) > 0 FROM app_user " +
+            "WHERE nickname = #{nickname}")
+    boolean nicknameExists(String nickname);
 }


### PR DESCRIPTION
# 📌 PR 내용
사용자 닉네임 중복 방지 기능 개선 작업을 완료했습니다.

## 🔨 개선 사항
* 소셜 로그인 가입 시 닉네임 중복 방지 로직 구현
  * 중복 닉네임 발생 시 랜덤 숫자 자동 추가
  * 최대 10회 시도 후에도 중복 시 타임스탬프 활용
* 프로필 수정 시 닉네임 중복 검사 추가