### PR TITLE
Fix: 모든강의 평점 불러오기 오류 수정

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/review/model/mapper/ReviewMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/review/model/mapper/ReviewMapper.java
@@ -117,11 +117,13 @@ public interface ReviewMapper {
     Double findAverageRatingByLectureId(Long lectureId);
 
     @Select("""
-      SELECT AVG(rating)
-        FROM review
-       WHERE mentor_id = #{mentorId}
-         AND status = 'AVAILABLE'
-         AND is_deleted = FALSE
+      SELECT AVG(r.rating)
+        FROM review r
+       INNER JOIN lecture l
+          ON r.lecture_id = l.lecture_id
+       WHERE l.mentor_id = #{mentorId}
+         AND r.status = 'AVAILABLE'
+         AND r.is_deleted = FALSE
     """)
     Double findAverageRatingByMentorId(Long mentorId);
 


### PR DESCRIPTION
리뷰의 개수는 출력이되는데 평점이 0으로 출력이되는버그가있었습니다
mapper의 쿼리를 수정하여 해결하였습니다 