### PR TITLE
Feat: 과외 매칭 취소 기능 구현

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/AccountMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/model/mapper/AccountMapper.java
@@ -83,9 +83,14 @@ public interface AccountMapper {
     int anonymizeDeletedUser(AppUser appUser);
 
     @Select("""
-        SELECT lecture_id
-          FROM lecture_mentee
-         WHERE mentee_id = #{userId}
-        """)
+        SELECT lm.lecture_id
+          FROM lecture_mentee lm
+          JOIN application a 
+              ON a.lecture_id = lm.lecture_id 
+                     AND a.mentee_id = lm.mentee_id
+         WHERE lm.mentee_id = #{userId}
+           AND a.status = 'APPROVED'
+           AND a.is_deleted = FALSE
+    """)
     List<Long> findLectureByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -117,5 +118,16 @@ public class ApplicationController {
         Long userId = userDetails.getUserId();
         List<MenteeResponseDto> result = applicationService.getMatchedMenteesByMentor(userId);
         return ResponseEntity.ok(ApiResponseFormat.ok(result));
+    }
+
+    @Operation(summary = "매칭 취소", description = "승인된 과외 매칭을 취소합니다. 매칭된 멘토만 취소할 수 있으며, 상태를 CANCELLED로 변경합니다.")
+    @PostMapping("/cancel/{applicationId}")
+    public ResponseEntity<ApiResponseFormat<Void>> cancelApplication(
+            @PathVariable Long applicationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        applicationService.cancelApplication(applicationId, userId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(null));
     }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
@@ -245,9 +245,13 @@ public interface ApplicationMapper {
             JOIN lecture l ON lm.lecture_id = l.lecture_id
             JOIN app_user u ON lm.mentee_id = u.user_id
             JOIN mentor_profile mp ON l.mentor_id = mp.mentor_id
+            JOIN application a ON a.lecture_id = lm.lecture_id
+                AND a.mentee_id = lm.mentee_id
             WHERE
                 mp.user_id = #{mentorId}
                 AND l.is_deleted = 0
+                AND a.status = 'APPROVED'
+                AND a.is_deleted = FALSE
             ORDER BY
                 lm.joined_at DESC
         """)
@@ -260,4 +264,18 @@ public interface ApplicationMapper {
               AND status = 'PENDING'
             """)
     int countDuplicateApplication(Long lectureId, Long menteeId);
+
+    @Select("""
+            SELECT lecture_id
+            FROM application 
+            WHERE application_id = #{applicationId}
+            """)
+    Long findLectureIdByApplicationId(Long applicationId);
+
+    @Update("""
+        UPDATE application
+        SET status = #{status}, updated_at = #{updatedTime}
+        WHERE application_id = #{applicationId}
+        """)
+    void updateApplicationStatus(Long applicationId, String status, LocalDateTime updatedTime);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
@@ -23,4 +23,6 @@ public interface ApplicationService {
     void applyForLecture(LectureApplyRequestDto dto, Long menteeId);
 
     List<MenteeResponseDto> getMatchedMenteesByMentor(Long mentorId);
+
+    void cancelApplication(Long applicationId, Long userId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/review/model/mapper/ReviewMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/review/model/mapper/ReviewMapper.java
@@ -125,9 +125,13 @@ public interface ReviewMapper {
 
     @Select("""
       SELECT COUNT(*) 
-        FROM lecture_mentee 
-       WHERE lecture_id = #{lectureId}
-         AND mentee_id  = #{userId}
+        FROM lecture_mentee lm
+        JOIN application a ON a.lecture_id = lm.lecture_id
+            AND a.mentee_id = lm.mentee_id
+       WHERE lm.lecture_id = #{lectureId}
+         AND lm.mentee_id  = #{userId}
+         AND a.status = 'APPROVED'
+         AND a.is_deleted = FALSE
     """)
     int countLectureMentee(@Param("lectureId") Long lectureId,
                            @Param("userId")    Long userId);


### PR DESCRIPTION
# 📌 PR 내용
매칭된 과외를 취소하는 기능을 구현했습니다.

## 🔨 구현 사항
- 승인된 과외 매칭을 취소할 수 있는 API 엔드포인트 추가
- 멘토와 멘티 모두 자신의 매칭을 취소할 수 있도록 구현
- 매칭 취소 시 Application 상태를 'CANCELLED'로 업데이트
- 취소 시 자동 메시지 전송