### PR TITLE
feat: 매칭 취소 로직 수정 및 닉네임/토큰 관련 기능 개선

### DIFF
--- a/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/controller/AccountController.java
@@ -43,6 +43,10 @@ public class AccountController {
             Authentication authentication,
             @RequestBody ProfileUpdateRequestDto requestDto
     ) {
+        if (requestDto.nickname() != null && requestDto.nickname().length() > 15) {
+            return ResponseEntity.badRequest().body(ApiResponseFormat.fail("닉네임은 15자 이하로 입력해주세요."));
+        }
+
         Long userId = ((CustomUserDetails) authentication.getPrincipal()).getUserId();
         accountService.updateProfile(userId, requestDto);
         return ResponseEntity.ok(ApiResponseFormat.ok(null));

--- a/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/account/service/AccountServiceImpl.java
@@ -54,6 +54,10 @@ public class AccountServiceImpl implements AccountService {
         AppUser appUser = accountMapper.findByUserId(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("AppUser", userId));
 
+        if (requestDto.nickname() != null && requestDto.nickname().length() > 15) {
+            throw new IllegalArgumentException("닉네임은 15자 이하로 입력해주세요.");
+        }
+
         if (!appUser.getNickname().equals(requestDto.nickname())
                 && appUserMapper.nicknameExists(requestDto.nickname())){
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다. 다른 닉네임을 선택해주세요.");

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/controller/ApplicationController.java
@@ -130,4 +130,15 @@ public class ApplicationController {
         applicationService.cancelApplication(applicationId, userId);
         return ResponseEntity.ok(ApiResponseFormat.ok(null));
     }
+
+    @Operation(summary = "매칭 ID로 매칭 취소", description = "matchId로 승인된 과외 매칭을 취소합니다.")
+    @PostMapping("/cancel/match/{matchId}")
+    public ResponseEntity<ApiResponseFormat<Void>> cancelMatchById(
+            @PathVariable Long matchId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        applicationService.cancelMatchById(matchId, userId);
+        return ResponseEntity.ok(ApiResponseFormat.ok(null));
+    }
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/model/mapper/ApplicationMapper.java
@@ -233,29 +233,31 @@ public interface ApplicationMapper {
 
     @Select("""
             SELECT
-                lm.match_id,
-                lm.lecture_id,
-                lm.mentee_id,
-                u.nickname,
-                u.profile_image,
-                l.lecture_title,
-                lm.matched_time_slots,
-                lm.joined_at
-            FROM lecture_mentee lm
-            JOIN lecture l ON lm.lecture_id = l.lecture_id
-            JOIN app_user u ON lm.mentee_id = u.user_id
-            JOIN mentor_profile mp ON l.mentor_id = mp.mentor_id
-            JOIN application a ON a.lecture_id = lm.lecture_id
-                AND a.mentee_id = lm.mentee_id
-            WHERE
-                mp.user_id = #{mentorId}
-                AND l.is_deleted = 0
-                AND a.status = 'APPROVED'
-                AND a.is_deleted = FALSE
-            ORDER BY
-                lm.joined_at DESC
+                 lm.match_id,
+                 lm.lecture_id,
+                 lm.mentee_id,
+                 u.nickname,
+                 u.profile_image,
+                 l.lecture_title,
+                 lm.matched_time_slots,
+                 lm.joined_at
+             FROM lecture_mentee lm
+             JOIN lecture l ON lm.lecture_id = l.lecture_id
+             JOIN app_user u ON lm.mentee_id = u.user_id
+             JOIN mentor_profile mp ON l.mentor_id = mp.mentor_id
+             JOIN (
+                 SELECT DISTINCT lecture_id, mentee_id
+                 FROM application
+                 WHERE status = 'APPROVED' AND is_deleted = FALSE
+             ) a ON a.lecture_id = lm.lecture_id AND a.mentee_id = lm.mentee_id
+             WHERE
+                 mp.user_id = #{mentorId}
+                 AND l.is_deleted = 0
+             ORDER BY
+                 lm.joined_at DESC
         """)
     List<MenteeResponseDto> findMatchedMenteesByMentorId(Long mentorId);
+
     @Select("""
             SELECT COUNT(*)
             FROM application
@@ -267,7 +269,7 @@ public interface ApplicationMapper {
 
     @Select("""
             SELECT lecture_id
-            FROM application 
+            FROM application
             WHERE application_id = #{applicationId}
             """)
     Long findLectureIdByApplicationId(Long applicationId);
@@ -278,4 +280,14 @@ public interface ApplicationMapper {
         WHERE application_id = #{applicationId}
         """)
     void updateApplicationStatus(Long applicationId, String status, LocalDateTime updatedTime);
+
+    @Select("""
+        SELECT a.application_id
+        FROM application a
+        JOIN lecture_mentee lm ON a.lecture_id = lm.lecture_id AND a.mentee_id = lm.mentee_id
+        WHERE lm.match_id = #{matchId}
+        AND a.status = 'APPROVED'
+        AND a.is_deleted = FALSE
+        """)
+    Long findApplicationIdByMatchId(Long matchId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/application/service/ApplicationService.java
@@ -25,4 +25,6 @@ public interface ApplicationService {
     List<MenteeResponseDto> getMatchedMenteesByMentor(Long mentorId);
 
     void cancelApplication(Long applicationId, Long userId);
+
+    void cancelMatchById(Long matchId, Long userId);
 }

--- a/src/main/java/aibe1/proj2/mentoss/feature/login/service/CustomOAuth2UserService.java
+++ b/src/main/java/aibe1/proj2/mentoss/feature/login/service/CustomOAuth2UserService.java
@@ -124,6 +124,10 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
             originalNickname = "멘티";
         }
 
+        if (originalNickname.length() > 11) {
+            originalNickname = originalNickname.substring(0, 11);
+        }
+
         String uniqueNickname;
         int maxAttempts = 10;
         int attempts = 0;

--- a/src/main/java/aibe1/proj2/mentoss/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/aibe1/proj2/mentoss/global/auth/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package aibe1.proj2.mentoss.global.auth;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,10 +19,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
-
         String authHeader = req.getHeader("Authorization");
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);
+
+            // 토큰 만료 여부 확인
+            if (jwtTokenProvider.isTokenExpired(token)) {
+                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                res.setContentType("application/json");
+                res.getWriter().write("{\"error\":\"token_expired\",\"message\":\"토큰이 만료되었습니다.\"}");
+                return;
+            }
+
+            // 유효한 토큰인 경우 처리
             if (jwtTokenProvider.validateToken(token)) {
                 Authentication auth = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/aibe1/proj2/mentoss/global/auth/JwtTokenProvider.java
+++ b/src/main/java/aibe1/proj2/mentoss/global/auth/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package aibe1.proj2.mentoss.global.auth;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -127,5 +128,19 @@ public class JwtTokenProvider {
         }
 
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    public boolean isTokenExpired(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSecretKey())
+                    .build()
+                    .parseSignedClaims(token);
+            return false;
+        } catch (ExpiredJwtException e) {
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
# 📌 PR내용
매칭 취소 로직 수정 및 닉네임/토큰 관련 기능 개선했습니다.

## 🔨 구현 사항
- 매칭 취소 기능 오류 수정
- 닉네임 입력값 15자 제한 로직 추가
- JWT 토큰 만료 시 응답 반환 로직 추가